### PR TITLE
Add VDA 277 JSON schema

### DIFF
--- a/VDA_231-301_Schema_VDA_277.json
+++ b/VDA_231-301_Schema_VDA_277.json
@@ -1,0 +1,2221 @@
+{
+  "$id": "https://github.com/VDA231-301/VDA_231-301__VDA_277/blob/main/VDA_231-301_Schema_VDA_277.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VDA 231-301 TestReport JSON schema for VDA 277",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "This is the Generic Schema which validates the structure of the file",
+  "properties": {
+    "_id": {
+      "$ref": "#/$defs/Generic.Identifier"
+    },
+    "_type": {
+      "const": "TestReport",
+      "type": "string"
+    },
+    "_schemaVersion": {
+      "const": "1.0.0",
+      "description": "The schema version on which the structure of the test report is based on."
+    },
+    "Title": {
+      "$ref": "#/$defs/Generic.RestrictedString"
+    },
+    "Client": {
+      "$ref": "#/$defs/Generic.Location"
+    },
+    "ClientOrderNumber": {
+      "$ref": "#/$defs/Generic.RestrictedString"
+    },
+    "Contractor": {
+      "$ref": "#/$defs/Generic.TestingCenter"
+    },
+    "LaboratoryOrderNumber": {
+      "$ref": "#/$defs/Generic.RestrictedString"
+    },
+    "OrderDate": {
+      "$ref": "#/$defs/Generic.Date"
+    },
+    "OrderReference": {
+      "$ref": "#/$defs/Generic.RestrictedString"
+    },
+    "ReportDate": {
+      "$ref": "#/$defs/Generic.Date"
+    },
+    "Signatory": {
+      "$ref": "#/$defs/Generic.ProperNameString"
+    },
+    "RemarkValidity": {
+      "$ref": "#/$defs/Generic.LongString"
+    },
+    "RemarkDeviation": {
+      "$ref": "#/$defs/Generic.LongString"
+    },
+    "RemarkInterpretations": {
+      "$ref": "#/$defs/Generic.LongString"
+    },
+    "Components": {
+      "items": {
+        "$ref": "#/$defs/Generic.Component"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "TestSeries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/VDA277.BranchingTestSeries"
+      },
+      "contains": {
+        "$ref": "#/$defs/VDA277.TestSeries"
+      }
+    }
+  },
+  "required": [
+    "_id",
+    "_type",
+    "_schemaVersion",
+    "ClientOrderNumber",
+    "LaboratoryOrderNumber",
+    "OrderReference",
+    "OrderDate",
+    "ReportDate",
+    "Signatory",
+    "Client",
+    "Contractor",
+    "Components",
+    "TestSeries"
+  ],
+  "$defs": {
+    "Generic.ArraySpec": {
+      "additionalProperties": false,
+      "properties": {
+        "Property": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Rounding": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "RoundingAccuracy": {
+          "type": "number"
+        },
+        "ValueResolution": {
+          "type": "number"
+        },
+        "LimitOfDetermination": {
+          "type": "number"
+        },
+        "MeasurementInaccuracy": {
+          "type": "number"
+        },
+        "Symbol": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Unit": {
+          "$ref": "#/$defs/Generic.Unit"
+        },
+        "ValueType": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "required": [
+        "Property"
+      ],
+      "type": "object"
+    },
+    "Generic.ArrayValue": {
+      "description": "An array that can contain strings, numbers, objects, arrays and null.",
+      "items": {
+        "$ref": "#/$defs/Generic.Value"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "Generic.Value": {
+      "description": "A generic value. Specific sub-schemas may restrict the type of the value.",
+      "anyOf": [
+        {
+          "description": "A string value.",
+          "example": "example string",
+          "type": "string"
+        },
+        {
+          "description": "A numerical value.",
+          "example": 42,
+          "type": "number"
+        },
+        {
+          "description": "An object value.",
+          "example": {
+            "key": "value"
+          },
+          "type": "object"
+        },
+        {
+          "description": "A boolean value.",
+          "type": "boolean"
+        },
+        {
+          "description": "An array of values",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Generic.Value"
+          }
+        },
+        {
+          "$ref": "#/$defs/Generic.NumberWithTolerance"
+        },
+        {
+          "$ref": "#/$defs/Generic.Date"
+        },
+        {
+          "description": "A null value",
+          "type": "null"
+        }
+      ]
+    },
+    "Generic.Attachment": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "_type": {
+          "const": "Attachment",
+          "type": "string"
+        },
+        "Data": {
+          "$ref": "#/$defs/Generic.Base64Encoding"
+        },
+        "FileName": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "MimeType": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Encoding": {
+          "const": "base64",
+          "type": "string"
+        },
+        "Hashes": {
+          "items": {
+            "$ref": "#/$defs/Generic.Hash"
+          },
+          "type": "array"
+        },
+        "Designation": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "type": "object",
+      "required": [
+        "_id",
+        "_type",
+        "Data",
+        "FileName",
+        "Encoding"
+      ]
+    },
+    "Generic.Base64Encoding": {
+      "description": "A Base64 encoded string.",
+      "example": "U29tZSBzYW1wbGUgZGF0YQ==",
+      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+      "type": "string"
+    },
+    "Generic.Certification": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Certification",
+          "type": "string"
+        },
+        "AccreditationDate": {
+          "$ref": "#/$defs/Generic.Date"
+        },
+        "Specification": {
+          "$ref": "#/$defs/Generic.Specification"
+        },
+        "ValidUntil": {
+          "$ref": "#/$defs/Generic.Date"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Specification",
+        "AccreditationDate"
+      ],
+      "type": "object"
+    },
+    "Generic.Location": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Location",
+          "type": "string"
+        },
+        "Identification": {
+          "$ref": "#/$defs/Generic.LocationIdentification"
+        },
+        "Name": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Address": {
+          "$ref": "#/$defs/Generic.ContactDetails"
+        },
+        "AddressNativeLanguage": {
+          "$ref": "#/$defs/Generic.ContactDetailsNative"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Identification"
+      ],
+      "type": "object"
+    },
+    "Generic.ConsolidatedCharacteristicValue": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/$defs/Generic.InformationPoint"
+        },
+        {
+          "properties": {
+            "_id": {
+              "$ref": "#/$defs/Generic.Identifier"
+            },
+            "_type": {
+              "const": "ConsolidatedCharacteristicValue",
+              "type": "string"
+            },
+            "Aggregation": {
+              "$ref": "#/$defs/Generic.RestrictedString"
+            },
+            "Comment": {
+              "$ref": "#/$defs/Generic.RestrictedText"
+            },
+            "CriterionType": {
+              "$ref": "#/$defs/Generic.RestrictedString"
+            },
+            "Attachment": {
+              "$ref": "#/$defs/Generic.Attachment"
+            }
+          }
+        }
+      ],
+      "required": [
+        "_id",
+        "_type",
+        "Aggregation"
+      ],
+      "type": "object"
+    },
+    "Generic.ContactDetails": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "ContactDetails",
+          "type": "string"
+        },
+        "Street": {
+          "$ref": "#/$defs/Generic.ProperNameString"
+        },
+        "Street2": {
+          "$ref": "#/$defs/Generic.ProperNameString"
+        },
+        "Street3": {
+          "$ref": "#/$defs/Generic.ProperNameString"
+        },
+        "HouseNumber": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "AdditionToAddress": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "ZipCode": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "City": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "StateRegion": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Country": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "EMail": {
+          "format": "email",
+          "type": "string"
+        },
+        "Fax": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Phone": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Phone",
+        "EMail"
+      ],
+      "type": "object"
+    },
+    "Generic.ContactDetailsNative": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "ContactDetailsNative",
+          "type": "string"
+        },
+        "Street": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Street2": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Street3": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "HouseNumber": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "AdditionToAddress": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "ZipCode": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "City": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "StateRegion": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Country": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "EMail": {
+          "format": "email",
+          "type": "string"
+        },
+        "Fax": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Phone": {
+          "$ref": "#/$defs/Generic.LongString"
+        }
+      },
+      "required": [
+        "_type"
+      ],
+      "type": "object"
+    },
+    "Generic.Date": {
+      "additionalProperties": false,
+      "properties": {
+        "Date": {
+          "description": "Date field that adheres to the ISO 8601 format (2000-02-01) or the European style (01.02.2000)",
+          "pattern": "^((\\d{4}-\\d{2}-\\d{2})|(\\d{2}\\.\\d{2}\\.\\d{4}))$",
+          "type": "string"
+        },
+        "Timestamp": {
+          "description": "Unix timestamp; time since January 1st 1970 UTC in seconds",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "Date"
+      ],
+      "type": "object"
+    },
+    "Generic.NumberWithTolerance": {
+      "prefixItems": [
+        {
+          "type": "number"
+        },
+        {
+          "properties": {
+            "MaxTolerance": {
+              "description": "The maximum tolerance value.",
+              "example": 0.5,
+              "type": "number"
+            },
+            "MinTolerance": {
+              "description": "The minimum tolerance value.",
+              "example": 0.1,
+              "type": "number"
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "type": "array"
+    },
+    "Generic.DateMonth": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}$",
+      "description": "Date string that only stores year and month in the ISO 8601 format 'YYYY-MM'"
+    },
+    "Generic.LocationIdentification": {
+      "description": "One or more identifiers for a location.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/Generic.LocationIdentifier"
+      }
+    },
+    "Generic.LocationIdentifier": {
+      "type": "object",
+      "properties": {
+        "Identifier": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Type": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "required": [
+        "Identifier",
+        "Type"
+      ]
+    },
+    "Generic.TestExecution": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "TestExecution",
+          "type": "string"
+        },
+        "Designation": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Numerator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "Tester": {
+          "$ref": "#/$defs/Generic.Person",
+          "description": "The person who executed the test."
+        },
+        "StartTime": {
+          "$ref": "#/$defs/Generic.Date",
+          "description": "The date the execution of the test began."
+        },
+        "MeasurementSystems": {
+          "items": {
+            "$ref": "#/$defs/Generic.MeasurementSystem"
+          },
+          "type": "array"
+        },
+        "RawData": {
+          "items": {
+            "$ref": "#/$defs/Generic.InformationSet"
+          },
+          "type": "array"
+        },
+        "SingleResults": {
+          "items": {
+            "$ref": "#/$defs/Generic.SingleResult"
+          },
+          "type": "array"
+        },
+        "Specimen": {
+          "$ref": "#/$defs/Generic.Specimen"
+        },
+        "TestParameters": {
+          "$ref": "#/$defs/Generic.InformationSet"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Designation",
+        "Numerator",
+        "Specimen",
+        "MeasurementSystems",
+        "RawData",
+        "SingleResults"
+      ],
+      "type": "object"
+    },
+    "Generic.Extraction": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Extraction",
+          "type": "string"
+        },
+        "Position": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Specification": {
+          "$ref": "#/$defs/Generic.Specification"
+        },
+        "Method": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Date": {
+          "$ref": "#/$defs/Generic.Date"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Method",
+        "Position",
+        "Specification"
+      ],
+      "type": "object"
+    },
+    "Generic.Hash": {
+      "additionalProperties": false,
+      "properties": {
+        "Type": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Value": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "type": "object"
+    },
+    "Generic.Identifier": {
+      "description": "Universally Unique Identifier (UUID) as a 128-bit value in hexadecimal coding, noted in five groups, standardised by RFC 4122[1].",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "Generic.InformationPoint": {
+      "properties": {
+        "Property": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Rounding": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "RoundingAccuracy": {
+          "type": "number"
+        },
+        "ValueResolution": {
+          "type": "number"
+        },
+        "LimitOfDetermination": {
+          "type": "number"
+        },
+        "MeasurementInaccuracy": {
+          "type": "number"
+        },
+        "Symbol": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Unit": {
+          "$ref": "#/$defs/Generic.Unit"
+        },
+        "ValueType": {
+          "oneOf": [
+            {
+              "const": "NumberWithTolerance"
+            },
+            {
+              "const": "Text"
+            },
+            {
+              "const": "Number"
+            },
+            {
+              "const": "List"
+            }
+          ]
+        },
+        "Value": {
+          "$ref": "#/$defs/Generic.Value"
+        },
+        "LocalizedText": {
+          "$ref": "#/$defs/Generic.ProperNameString"
+        }
+      },
+      "required": [
+        "Property",
+        "Value"
+      ],
+      "type": "object"
+    },
+    "Generic.InformationSet": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "InformationSet",
+          "type": "string"
+        },
+        "ArraySpec": {
+          "items": {
+            "$ref": "#/$defs/Generic.ArraySpec"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "ArrayValue": {
+          "items": {
+            "$ref": "#/$defs/Generic.ArrayValue"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "Attributes": {
+          "items": {
+            "$ref": "#/$defs/Generic.InformationPoint",
+            "unevaluatedProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "Designation": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        }
+      },
+      "required": [
+        "_id",
+        "_type"
+      ],
+      "anyOf": [
+        {
+          "required": [
+            "Attributes"
+          ]
+        },
+        {
+          "required": [
+            "ArraySpec",
+            "ArrayValue"
+          ]
+        }
+      ],
+      "type": "object"
+    },
+    "Generic.LongString": {
+      "description": "A string with a maximum length of 240 and no leading or trailing whitespaces.",
+      "maxLength": 240,
+      "pattern": "^(?!\\s).*(?<!\\s)$",
+      "type": "string"
+    },
+    "Generic.RestrictedText": {
+      "description": "A string with max length of 1000 and only 7-bit ASCII characters",
+      "maxLength": 1000,
+      "minLength": 0,
+      "pattern": "^[\\x20-\\x7E]*$",
+      "type": "string"
+    },
+    "Generic.MeasurementSystem": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "MeasurementSystem",
+          "type": "string"
+        },
+        "Designation": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "SystemType": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Location": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "MeasurementSetup": {
+          "$ref": "#/$defs/Generic.Attachment"
+        },
+        "Specification": {
+          "$ref": "#/$defs/Generic.Specification"
+        },
+        "Accuracy": {
+          "$ref": "#/$defs/Generic.InformationSet"
+        },
+        "CalibrationData": {
+          "items": {
+            "$ref": "#/$defs/Generic.Calibration"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Designation",
+        "SystemType"
+      ],
+      "type": "object"
+    },
+    "Generic.Calibration": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Calibration",
+          "type": "string"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        },
+        "Date": {
+          "$ref": "#/$defs/Generic.Date"
+        },
+        "ValidUntil": {
+          "$ref": "#/$defs/Generic.Date"
+        }
+      },
+      "required": [
+        "_id",
+        "_type"
+      ],
+      "type": "object"
+    },
+    "Generic.ProcessStep": {
+      "additionalProperties": false,
+      "description": "A schema representing a single step in a process, including its index and associated specification.",
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "ProcessStep",
+          "type": "string"
+        },
+        "Specification": {
+          "$ref": "#/$defs/Generic.Specification",
+          "description": "The specification associated with this process step."
+        },
+        "Index": {
+          "description": "The sequential index of the process step.",
+          "example": 1,
+          "type": "integer"
+        },
+        "ProcessData": {
+          "$ref": "#/$defs/Generic.InformationSet",
+          "description": "The information set related to this process step."
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.RestrictedText"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Index"
+      ],
+      "type": "object"
+    },
+    "Generic.PropertyWithTolerance": {
+      "additionalProperties": false,
+      "description": "A schema representing a property with its value, unit, and tolerance.",
+      "properties": {
+        "MaxTolerance": {
+          "description": "The maximum tolerance value.",
+          "example": 0.5,
+          "type": "number"
+        },
+        "MinTolerance": {
+          "description": "The minimum tolerance value.",
+          "example": 0.1,
+          "type": "number"
+        },
+        "Property": {
+          "$ref": "#/$defs/Generic.RestrictedString",
+          "description": "The name of the property."
+        },
+        "Unit": {
+          "$ref": "#/$defs/Generic.Unit",
+          "description": "The unit of measurement for the property value."
+        },
+        "Value": {
+          "description": "The value of the property.",
+          "example": 100.0,
+          "type": "number"
+        },
+        "ValueType": {
+          "$ref": "#/$defs/Generic.RestrictedString",
+          "description": "The type of the property value."
+        }
+      },
+      "required": [
+        "Property",
+        "Value",
+        "Unit"
+      ],
+      "type": "object"
+    },
+    "Generic.Specification": {
+      "additionalProperties": false,
+      "properties": {
+        "Authority": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Type": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Number": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "SubNumber": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "IssueDate": {
+          "$ref": "#/$defs/Generic.DateMonth"
+        },
+        "Title": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "FeatureText": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "FeatureList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Generic.RestrictedString"
+          },
+          "example": [
+            "23",
+            "R",
+            "6/4"
+          ]
+        },
+        "DOI": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Type",
+        "Number",
+        "IssueDate"
+      ],
+      "type": "object"
+    },
+    "Generic.SingleResult": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/$defs/Generic.InformationPoint"
+        },
+        {
+          "properties": {
+            "_id": {
+              "$ref": "#/$defs/Generic.Identifier"
+            },
+            "_type": {
+              "const": "SingleResult",
+              "type": "string"
+            },
+            "ConsolidatedValueID": {
+              "$ref": "#/$defs/Generic.Identifier"
+            },
+            "Comment": {
+              "$ref": "#/$defs/Generic.RestrictedText"
+            },
+            "Attachment": {
+              "$ref": "#/$defs/Generic.Attachment"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "Generic.Specimen": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Specimen",
+          "type": "string"
+        },
+        "Designation": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Flagging": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.RestrictedText"
+        },
+        "ComponentID": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        },
+        "AdditionalProperties": {
+          "$ref": "#/$defs/Generic.InformationSet"
+        },
+        "Extraction": {
+          "$ref": "#/$defs/Generic.Extraction"
+        },
+        "ProcessHistory": {
+          "description": "An array of processing steps.",
+          "items": {
+            "$ref": "#/$defs/Generic.ProcessStep"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "ComponentID",
+        "Designation"
+      ],
+      "type": "object"
+    },
+    "Generic.TestingCenter": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "TestingCenter",
+          "type": "string"
+        },
+        "Location": {
+          "$ref": "#/$defs/Generic.Location"
+        },
+        "TestingManager": {
+          "$ref": "#/$defs/Generic.Person"
+        },
+        "Certifications": {
+          "items": {
+            "$ref": "#/$defs/Generic.Certification"
+          },
+          "type": "array"
+        },
+        "VatId": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Location",
+        "TestingManager",
+        "Certifications"
+      ],
+      "type": "object"
+    },
+    "Generic.Person": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Person",
+          "type": "string"
+        },
+        "FirstName": {
+          "$ref": "#/$defs/Generic.ProperNameString"
+        },
+        "MiddleName": {
+          "$ref": "#/$defs/Generic.ProperNameString"
+        },
+        "LastName": {
+          "$ref": "#/$defs/Generic.ProperNameString"
+        },
+        "Title": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "OrganizationIdentification": {
+          "$ref": "#/$defs/Generic.LocationIdentification"
+        },
+        "ID-Number": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "EMail": {
+          "format": "email",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_id",
+        "_type"
+      ],
+      "type": "object"
+    },
+    "Generic.Component": {
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Component",
+          "type": "string"
+        },
+        "PartNumber": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Color": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "ProductionSite": {
+          "$ref": "#/$defs/Generic.Location"
+        },
+        "Machine": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Tool": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Cavity": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "SerialNumber": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "ProductionBatchNumber": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "ProductionDate": {
+          "$ref": "#/$defs/Generic.Date"
+        },
+        "MaterialGroup": {
+          "$ref": "#/$defs/Generic.RestrictedString",
+          "description": "According to VDA 231-106"
+        },
+        "MaterialClass": {
+          "$ref": "#/$defs/Generic.RestrictedString",
+          "description": "According to VDA 231-200"
+        },
+        "MaterialName": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "MaterialIdentifiers": {
+          "items": {
+            "$ref": "#/$defs/Generic.RestrictedString"
+          },
+          "type": "array",
+          "description": "According to VDA 231-300"
+        },
+        "SurfaceIdentifiers": {
+          "items": {
+            "$ref": "#/$defs/Generic.RestrictedString"
+          },
+          "type": "array",
+          "description": "According to VDA 231-300"
+        },
+        "Specifications": {
+          "items": {
+            "$ref": "#/$defs/Generic.Specification"
+          },
+          "type": "array",
+          "description": "A list of associated specifications regarding this component."
+        },
+        "LayerSequence": {
+          "$ref": "#/$defs/Generic.InformationSet"
+        },
+        "DateOfReceipt": {
+          "$ref": "#/$defs/Generic.Date"
+        },
+        "Attachments": {
+          "items": {
+            "$ref": "#/$defs/Generic.Attachment"
+          },
+          "type": "array"
+        },
+        "DeviationSpecificationText": {
+          "$ref": "#/$defs/Generic.RestrictedText",
+          "description": "The text describing allowed deviation from the specification."
+        },
+        "DeviationSpecificationCodeFile": {
+          "$ref": "#/$defs/Generic.Attachment",
+          "description": "The JSON file containing the deviation specification code."
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.RestrictedText",
+          "description": "Additional information about the component."
+        }
+      },
+      "required": [
+        "_id",
+        "_type"
+      ],
+      "type": "object"
+    },
+    "Generic.TestSeries": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "TestSeries",
+          "type": "string"
+        },
+        "Specification": {
+          "$ref": "#/$defs/Generic.Specification"
+        },
+        "TestType": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "AdditionalInformation": {
+          "$ref": "#/$defs/Generic.InformationSet",
+          "additionalProperties": false
+        },
+        "NumberOfExecutions": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "Assessment": {
+          "type": "string"
+        },
+        "PredecessorId": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Generic.Identifier"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "SuccessorId": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Generic.Identifier"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "TestingCenter": {
+          "$ref": "#/$defs/Generic.TestingCenter"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.RestrictedText"
+        },
+        "Executions": {
+          "items": {
+            "$ref": "#/$defs/Generic.TestExecution"
+          },
+          "type": "array"
+        },
+        "ConsolidatedCharacteristicValues": {
+          "items": {
+            "$ref": "#/$defs/Generic.ConsolidatedCharacteristicValue"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Specification",
+        "NumberOfExecutions",
+        "PredecessorId",
+        "SuccessorId",
+        "TestingCenter",
+        "ConsolidatedCharacteristicValues"
+      ],
+      "type": "object"
+    },
+    "Generic.RestrictedString": {
+      "allOf": [
+        {
+          "not": {
+            "pattern": "^\\s"
+          }
+        },
+        {
+          "not": {
+            "pattern": "\\s$"
+          }
+        }
+      ],
+      "description": "A string with max length of 50, no leading or trailing whitespace, and only 7-bit ASCII characters",
+      "maxLength": 50,
+      "minLength": 0,
+      "pattern": "^[\\x20-\\x7E]*$",
+      "type": "string"
+    },
+    "Generic.Unit": {
+      "allOf": [
+        {
+          "not": {
+            "pattern": "^\\s"
+          }
+        },
+        {
+          "not": {
+            "pattern": "\\s$"
+          }
+        }
+      ],
+      "description": "A string with max length of 20, no leading or trailing whitespace, and only 7-bit ASCII characters plus Ω and µ",
+      "maxLength": 20,
+      "minLength": 0,
+      "pattern": "^[°Ωµ\\x20-\\x7E]*$",
+      "type": "string",
+      "examples": [
+        "Ω",
+        "µg*m^-3"
+      ]
+    },
+    "Generic.ProperNameString": {
+      "allOf": [
+        {
+          "not": {
+            "pattern": "^\\s"
+          }
+        },
+        {
+          "not": {
+            "pattern": "\\s$"
+          }
+        }
+      ],
+      "description": "A string with max length of 80, no leading or trailing whitespace, and only the Unicode code pages Basic Latin & Latin-1 Supplement",
+      "maxLength": 80,
+      "minLength": 0,
+      "pattern": "^[\\u0020-\\u00FF]*$",
+      "type": "string"
+    },
+    "VDA277.BranchingTestSeries": {
+      "type": "object",
+      "if": {
+        "properties": {
+          "Specification": {
+            "type": "object",
+            "properties": {
+              "Type": {
+                "const": "VDA",
+                "type": "string"
+              },
+              "Number": {
+                "const": "277",
+                "type": "string"
+              },
+              "IssueDate": {
+                "const": "2016-05",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/VDA277.TestSeries"
+      },
+      "else": {
+        "$ref": "#/$defs/Generic.TestSeries"
+      }
+    },
+    "VDA277.TestSeries": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "TestSeries",
+          "type": "string"
+        },
+        "Specification": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Generic.Specification"
+            },
+            {
+              "properties": {
+                "Type": {
+                  "const": "VDA",
+                  "type": "string"
+                },
+                "Number": {
+                  "const": "277",
+                  "type": "string"
+                },
+                "IssueDate": {
+                  "const": "2016-05",
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "TestType": {
+          "const": "Headspace GC",
+          "type": "string"
+        },
+        "FeaturesAccordingToSpecification": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "AdditionalInformation": {
+          "$ref": "#/$defs/Generic.InformationSet",
+          "additionalProperties": false
+        },
+        "NumberOfExecutions": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "Assessment": {
+          "type": "string"
+        },
+        "PredecessorId": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Generic.Identifier"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "SuccessorId": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Generic.Identifier"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "TestingCenter": {
+          "$ref": "#/$defs/Generic.TestingCenter"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Executions": {
+          "items": {
+            "$ref": "#/$defs/VDA277.TestExecution"
+          },
+          "type": "array"
+        },
+        "ConsolidatedCharacteristicValues": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "$ref": "#/$defs/VDA277.ConsolidatedCharacteristicValueVOCTotalEmission"
+            }
+          ],
+          "items": {
+            "$ref": "#/$defs/Generic.ConsolidatedCharacteristicValue"
+          }
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "TestType",
+        "Specification",
+        "NumberOfExecutions",
+        "TestingCenter",
+        "ConsolidatedCharacteristicValues",
+        "PredecessorId",
+        "SuccessorId"
+      ]
+    },
+    "VDA277.TestExecution": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "TestExecution",
+          "type": "string"
+        },
+        "Designation": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Numerator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "Tester": {
+          "$ref": "#/$defs/Generic.Person",
+          "description": "The person who executed the test."
+        },
+        "StartTime": {
+          "$ref": "#/$defs/Generic.Date",
+          "description": "The date the execution of the test began."
+        },
+        "MeasurementSystems": {
+          "items": {
+            "$ref": "#/$defs/Generic.MeasurementSystem"
+          },
+          "type": "array"
+        },
+        "RawData": {
+          "items": {
+            "$ref": "#/$defs/VDA277.InformationSetRawData"
+          },
+          "type": "array"
+        },
+        "SingleResults": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "Specimen": {
+          "$ref": "#/$defs/VDA277.Specimen"
+        },
+        "TestParameters": {
+          "$ref": "#/$defs/Generic.InformationSet"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Designation",
+        "Numerator",
+        "Specimen",
+        "MeasurementSystems",
+        "RawData",
+        "SingleResults"
+      ],
+      "type": "object"
+    },
+    "VDA277.InformationSetRawData": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "InformationSet",
+          "type": "string"
+        },
+        "Designation": {
+          "const": "VOC",
+          "type": "string"
+        },
+        "ArraySpec": {
+          "$ref": "#/$defs/VDA277.RawDataArraySpec"
+        },
+        "ArrayValue": {
+          "items": {
+            "$ref": "#/$defs/VDA277.RawDataArrayValue"
+          },
+          "minItems": 0,
+          "type": "array"
+        },
+        "Attributes": {
+          "items": {
+            "$ref": "#/$defs/VDA277.RawDataAttribute",
+            "unevaluatedProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Designation",
+        "ArraySpec",
+        "ArrayValue"
+      ],
+      "type": "object"
+    },
+    "VDA277.RawDataArraySpec": {
+      "type": "array",
+      "minItems": 10,
+      "maxItems": 10,
+      "description": "An array specification for storing VDA 277 test results.",
+      "const": [
+        {
+          "Property": "Retention time",
+          "Unit": "min"
+        },
+        {
+          "Property": "Substance name"
+        },
+        {
+          "Property": "Legacy substance"
+        },
+        {
+          "Property": "Mass fragments"
+        },
+        {
+          "Property": "Main mass fragment"
+        },
+        {
+          "Property": "Potential substance match"
+        },
+        {
+          "Property": "CAS registry number"
+        },
+        {
+          "Property": "Area",
+          "Unit": "%"
+        },
+        {
+          "Property": "Emission",
+          "Unit": "µg/g"
+        },
+        {
+          "Property": "Remark"
+        }
+      ]
+    },
+    "VDA277.RawDataArrayValue": {
+      "description": "An array value type for storing VDA 277 test results.",
+      "prefixItems": [
+        {
+          "type": "number",
+          "minimum": 0.0
+        },
+        {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]{2,7}[-][0-9]{2}[-][0-9]{1}$"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 100.0
+        },
+        {
+          "type": "number",
+          "minimum": 0.0
+        },
+        {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      ],
+      "minItems": 10,
+      "maxItems": 10,
+      "type": "array"
+    },
+    "VDA277.RawDataAttribute": {
+      "type": "object",
+      "required": [
+        "Property",
+        "Value"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeMethod"
+        },
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeFileName"
+        },
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeVOCTotalEmissionValue"
+        },
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeRemark"
+        },
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeSumIdentifiedSubstancesArea"
+        },
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeSumIdentifiedSubstancesEmission"
+        },
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeVialNumber"
+        },
+        {
+          "$ref": "#/$defs/VDA277.RawDataAttributeClassifications"
+        }
+      ]
+    },
+    "VDA277.RawDataAttributeMethod": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Method"
+        },
+        "ValueType": {
+          "const": "Text"
+        },
+        "Value": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "required": [
+        "Property",
+        "Value"
+      ]
+    },
+    "VDA277.RawDataAttributeFileName": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "File name"
+        },
+        "ValueType": {
+          "const": "Text"
+        },
+        "Value": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "required": [
+        "Property",
+        "Value"
+      ]
+    },
+    "VDA277.RawDataAttributeRemark": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Remark"
+        },
+        "ValueType": {
+          "const": "Text"
+        },
+        "Value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Property",
+        "Value"
+      ]
+    },
+    "VDA277.RawDataAttributeSumIdentifiedSubstancesArea": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Sum of identified substances area"
+        },
+        "Unit": {
+          "const": "%"
+        },
+        "Value": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 100.0
+        },
+        "Rounding": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "RoundingAccuracy": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "Property",
+        "Unit",
+        "Value"
+      ]
+    },
+    "VDA277.RawDataAttributeSumIdentifiedSubstancesEmission": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Sum of identified substances emission"
+        },
+        "Unit": {
+          "const": "µg/g"
+        },
+        "Value": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "Rounding": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "RoundingAccuracy": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "Property",
+        "Unit",
+        "Value"
+      ]
+    },
+    "VDA277.RawDataAttributeVialNumber": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Vial Number"
+        },
+        "ValueType": {
+          "const": "Text"
+        },
+        "Value": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        }
+      },
+      "required": [
+        "Property",
+        "Value"
+      ]
+    },
+    "VDA277.RawDataAttributeClassifications": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Classifications"
+        },
+        "Value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VDA277.RawDataAttributeClassificationItem"
+          },
+          "minItems": 0
+        }
+      },
+      "required": [
+        "Property",
+        "Value"
+      ]
+    },
+    "VDA277.RawDataAttributeClassificationItem": {
+      "type": "object",
+      "properties": {
+        "CAS registry number": {
+          "type": "string",
+          "pattern": "^[0-9]{2,7}[-][0-9]{2}[-][0-9]{1}$"
+        },
+        "Regulations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VDA277.RawDataAttributeClassificationBranchingRegulationItem"
+          }
+        }
+      },
+      "required": [
+        "CAS registry number",
+        "Regulations"
+      ]
+    },
+    "VDA277.RawDataAttributeClassificationBranchingRegulationItem": {
+      "type": "object",
+      "if": {
+        "properties": {
+          "Regulation": {
+            "type": "string",
+            "const": "GADSL"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/VDA277.RawDataAttributeClassificationGADSLRegulationItem"
+      },
+      "else": {
+        "$ref": "#/$defs/VDA277.RawDataAttributeClassificationRegulationItem"
+      }
+    },
+    "VDA277.RawDataAttributeClassificationRegulationItem": {
+      "type": "object",
+      "properties": {
+        "Regulation": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Values": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/Generic.RestrictedString"
+          }
+        }
+      },
+      "required": [
+        "Regulation",
+        "Values"
+      ]
+    },
+    "VDA277.RawDataAttributeClassificationGADSLRegulationItem": {
+      "type": "object",
+      "properties": {
+        "Regulation": {
+          "type": "string",
+          "const": "GADSL"
+        },
+        "Values": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "const": "D"
+              },
+              {
+                "const": "P"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "Regulation",
+        "Values"
+      ]
+    },
+    "VDA277.Specimen": {
+      "additionalProperties": false,
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "Specimen",
+          "type": "string"
+        },
+        "Designation": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Flagging": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "ComponentID": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        },
+        "AdditionalProperties": {
+          "$ref": "#/$defs/Generic.InformationSet"
+        },
+        "Extraction": {
+          "$ref": "#/$defs/Generic.Extraction"
+        },
+        "ProcessHistory": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "$ref": "#/$defs/VDA277.ProcessStepPreconditioning"
+          }
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "ComponentID",
+        "Designation"
+      ],
+      "type": "object"
+    },
+    "VDA277.ProcessStepPreconditioning": {
+      "type": "object",
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "ProcessStep"
+        },
+        "Specification": {
+          "const": {
+            "Type": "VDA",
+            "Number": "277",
+            "IssueDate": "2016-05"
+          }
+        },
+        "Index": {
+          "type": "integer"
+        },
+        "ProcessData": {
+          "$ref": "#/$defs/VDA277.ProcessDataPreconditioning"
+        },
+        "Comment": {
+          "$ref": "#/$defs/Generic.LongString"
+        },
+        "Attachment": {
+          "$ref": "#/$defs/Generic.Attachment"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Specification",
+        "Index",
+        "ProcessData"
+      ]
+    },
+    "VDA277.ProcessDataPreconditioning": {
+      "type": "object",
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "InformationSet"
+        },
+        "Designation": {
+          "const": "Preconditioning"
+        },
+        "Attributes": {
+          "type": "array",
+          "maxItems": 6,
+          "prefixItems": [
+            {
+              "$ref": "#/$defs/VDA277.ProcessDataPreconditioningDuration"
+            },
+            {
+              "$ref": "#/$defs/VDA277.ProcessDataPreconditioningEndDate"
+            },
+            {
+              "$ref": "#/$defs/VDA277.ProcessDataPreconditioningTempMin"
+            },
+            {
+              "$ref": "#/$defs/VDA277.ProcessDataPreconditioningTempMax"
+            },
+            {
+              "$ref": "#/$defs/VDA277.ProcessDataPreconditioningHumidMin"
+            },
+            {
+              "$ref": "#/$defs/VDA277.ProcessDataPreconditioningHumidMax"
+            }
+          ]
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Designation",
+        "Attributes"
+      ]
+    },
+    "VDA277.ProcessDataPreconditioningDuration": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Duration"
+        },
+        "Unit": {
+          "const": "d"
+        },
+        "Value": {
+          "type": "number",
+          "minimum": 0.0
+        }
+      }
+    },
+    "VDA277.ProcessDataPreconditioningEndDate": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "End date"
+        },
+        "Value": {
+          "$ref": "#/$defs/Generic.Date"
+        }
+      }
+    },
+    "VDA277.ProcessDataPreconditioningTempMin": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Temperature minimum"
+        },
+        "Unit": {
+          "const": "°C"
+        },
+        "Value": {
+          "type": "number"
+        }
+      }
+    },
+    "VDA277.ProcessDataPreconditioningTempMax": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Temperature maximum"
+        },
+        "Unit": {
+          "const": "°C"
+        },
+        "Value": {
+          "type": "number"
+        }
+      }
+    },
+    "VDA277.ProcessDataPreconditioningHumidMin": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Relative humidity minimum"
+        },
+        "Unit": {
+          "const": "%"
+        },
+        "Value": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 100.0
+        }
+      }
+    },
+    "VDA277.ProcessDataPreconditioningHumidMax": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "Relative humidity maximum"
+        },
+        "Unit": {
+          "const": "%"
+        },
+        "Value": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 100.0
+        }
+      }
+    },
+    "VDA277.RawDataAttributeVOCTotalEmissionValue": {
+      "type": "object",
+      "properties": {
+        "Property": {
+          "const": "VOC total emission value"
+        },
+        "Unit": {
+          "const": "µg/g"
+        },
+        "Value": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "Rounding": {
+          "$ref": "#/$defs/Generic.RestrictedString"
+        },
+        "RoundingAccuracy": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "Property",
+        "Unit",
+        "Value"
+      ]
+    },
+    "VDA277.ConsolidatedCharacteristicValueVOCTotalEmission": {
+      "type": "object",
+      "properties": {
+        "_id": {
+          "$ref": "#/$defs/Generic.Identifier"
+        },
+        "_type": {
+          "const": "ConsolidatedCharacteristicValue",
+          "type": "string"
+        },
+        "Property": {
+          "const": "VOC total emission value",
+          "type": "string"
+        },
+        "Unit": {
+          "const": "µg/g",
+          "type": "string"
+        },
+        "Value": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "Aggregation": {
+          "const": "None",
+          "type": "string"
+        },
+        "CriterionType": {
+          "const": "Variable/Quantitative",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "Property",
+        "Unit",
+        "Value",
+        "Aggregation",
+        "CriterionType"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add VDA 277 test report schema based on existing VDA 278 specification
- restrict schema to VOC measurements and headspace GC test type
- define VOC total emission characteristics and raw data attributes

## Testing
- `python - <<'PY'
import json, jsonschema
schema=json.load(open('VDA_231-301_Schema_VDA_277.json'))
jsonschema.Draft202012Validator.check_schema(schema)
print('Schema valid')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ad9bc16a048327a89a3a6b2e5e74a2